### PR TITLE
axiosのbaseURLの修正

### DIFF
--- a/src/main/resources/templates/users/mypage.html
+++ b/src/main/resources/templates/users/mypage.html
@@ -204,7 +204,7 @@
 
 
         const apiClient = axios.create({
-            baseURL: "http://localhost:8080/api/users",
+            baseURL: "/api/users",
             headers: {
                 'Content-Type': 'application/json',
                 'Accept': 'application/json',


### PR DESCRIPTION
axiosのbaseURLにlocalhost, portまで指定するとPCのchromeからAPIをコールできるが、androidのchromeからはnet::ERR_CONNECTION_REFUSEDとなるため、ホスト名まで指定しないように修正する。